### PR TITLE
fix: decode .st/text files as UTF-8 in reverse-pipe daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### Unreleased
+
+**Fixes:**
+
+- Fixed non-ASCII text (e.g. CJK comments) turning into mojibake (`製程` → `è£½ç¨`) when `.st` files are round-tripped through the reverse-pipe daemon. The IronPython 2.7 daemon read `.st` files in byte-string text mode and fed the raw UTF-8 bytes straight into CODESYS text properties, where .NET reinterprets each byte as Latin-1; the corruption then surfaced as double-encoded UTF-8 on the next export. Daemon file reads (`update_pou`, `sync_import_text`, `sync_compare_text`, `cicd`) and the build-result output file now decode/encode UTF-8 explicitly. The Python 3 external engine was already UTF-8-safe and is unaffected.
+
+---
+
 ### Version 2.5.1 (2026-05-28)
 
 **CLI & Daemon:**

--- a/src/ide_bridge/ide_daemon.pyw
+++ b/src/ide_bridge/ide_daemon.pyw
@@ -10,6 +10,7 @@ from __future__ import print_function
 import clr
 import sys
 import os
+import io
 import json
 import time
 import traceback
@@ -458,7 +459,9 @@ class DaemonPipeServer(object):
             tmp = tempfile.mktemp(suffix=".xml")
             try:
                 project.export_native([target], tmp, recursive=False)
-                with open(tmp, "r") as f:
+                # Decode as UTF-8 so non-ASCII (e.g. CJK) content is not corrupted
+                # by IronPython's byte-string text-mode read. See ide_reverse_pipe_loop.
+                with io.open(tmp, "r", encoding="utf-8-sig") as f:
                     content = f.read()
                 info = {
                     "name": self._obj_name(target),

--- a/src/ide_bridge/ide_reverse_pipe_loop.py
+++ b/src/ide_bridge/ide_reverse_pipe_loop.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import clr
 import sys
 import os
+import io
 import json
 import time
 import tempfile
@@ -63,6 +64,22 @@ def _log(msg):
             f.write(line + "\n")
     except Exception:
         pass
+
+
+def _read_text_utf8(path):
+    """Read a text file as UTF-8 and return a unicode string.
+
+    IronPython 2.7's builtin open(path, "r").read() returns the file's raw bytes
+    as a byte-string without decoding. Feeding those bytes straight into a
+    CODESYS text property (e.g. textual_declaration.text) makes .NET reinterpret
+    each UTF-8 byte as Latin-1, which corrupts non-ASCII text (e.g. CJK becomes
+    mojibake) and is then serialised back out as double-encoded UTF-8 on the next
+    export. Decoding as UTF-8 here yields a proper unicode string that
+    round-trips correctly through the CODESYS scripting API. utf-8-sig also
+    tolerates a BOM that an external editor may have added to the file.
+    """
+    with io.open(path, "r", encoding="utf-8-sig") as handle:
+        return handle.read()
 
 
 # ── UI Dashboard (WinForms) ────────────────────────────────────────────────
@@ -921,8 +938,8 @@ def _cmd_build(params):
         output_path = params.get("output") if isinstance(params, dict) else None
         if output_path:
             try:
-                with open(output_path, "w") as f:
-                    json.dump(result, f, indent=2, ensure_ascii=False)
+                with open(output_path, "wb") as f:
+                    f.write(json.dumps(result, indent=2, ensure_ascii=False).encode("utf-8"))
                 result["data"]["output_file"] = output_path
             except Exception as e:
                 result["data"]["output_error"] = str(e)
@@ -2935,8 +2952,7 @@ def _cmd_sync_import_text(params):
                         decl = ""
                         impl = ""
                         if st_path and os.path.exists(st_path):
-                            with open(st_path, "r") as f:
-                                content = f.read()
+                            content = _read_text_utf8(st_path)
                             decl, impl = _split_st_content(content)
                         
                         text_creates.append({
@@ -3084,8 +3100,7 @@ def _cmd_sync_compare_text(params):
         
     # Step 3: Read and return report
     try:
-        with open(report_path, "r", encoding="utf-8") as f:
-            report_data = json.load(f)
+        report_data = json.loads(_read_text_utf8(report_path))
         return {"ok": True, "data": report_data}
     except Exception as e:
          return {"ok": False, "error": "failed to read report: " + str(e)}
@@ -3121,9 +3136,8 @@ def _cmd_update_pou(params):
         return {"ok": False, "error": "File not found: {0}".format(st_path)}
     
     # Read .st file
-    with open(st_path, "r") as f:
-        content = f.read()
-    
+    content = _read_text_utf8(st_path)
+
     # Split into declaration and implementation
     marker = "// --- implementation ---"
     decl = content
@@ -3348,8 +3362,7 @@ def _cmd_cicd(params):
             fp = os.path.join(test_dir, jf)
             plan = {}
             try:
-                with open(fp, "r") as fh:
-                    plan = json.load(fh)
+                plan = json.loads(_read_text_utf8(fp))
             except Exception as e:
                 results.append({"file": jf, "status": "FAIL", "error": str(e)})
                 continue
@@ -3372,8 +3385,7 @@ def _cmd_cicd(params):
     
     # Read and execute
     try:
-        with open(file_path, "r") as fh:
-            plan = json.load(fh)
+        plan = json.loads(_read_text_utf8(file_path))
     except Exception as e:
         return {"ok": False, "error": "Failed to parse test file: {0}".format(e)}
     


### PR DESCRIPTION
## Problem

Non-ASCII text (e.g. CJK comments) becomes mojibake (`製程` -> `è£½ç¨`) when `.st` files are round-tripped through the reverse-pipe daemon, and surfaces as garbage on the next export.

## Root cause

`ide_reverse_pipe_loop.py` (IronPython 2.7) read `.st` files with the builtin text-mode `open(path, "r").read()`, which returns the file's raw bytes as a byte-string without decoding. Passing those bytes into a CODESYS text property (e.g. `textual_declaration.text`) makes .NET reinterpret each UTF-8 byte as Latin-1, so the project stores `製程` as `è£½ç¨`; `export_native` then serialises it back out as double-encoded UTF-8.

Confirmed: `製` (UTF-8 `E8 A3 BD`) read as Latin-1 -> `è£½`, matching the reported garbage byte-for-byte.

## Fix

- Add a `_read_text_utf8()` helper (`io.open(..., encoding="utf-8-sig")`) and use it for the daemon's `.st` and JSON reads: `update_pou`, `sync_import_text`, `sync_compare_text`, `cicd`.
- The compare-report read also passed an `encoding=` kwarg that the IronPython 2.7 builtin `open()` does not accept; routed through the helper.
- Write the build-result output via binary + `.encode("utf-8")` so `ensure_ascii=False` output can't be corrupted by text-mode encoding.
- Apply the same fix to the legacy forward-pipe daemon (`ide_daemon.pyw`).

The Python 3 external engine already used `codecs.open(..., "utf-8")` and `ET.parse` throughout, so it was unaffected (the in-IDE `Project_*.py` workflow is fine).

## Verification

Round-trip simulation: the old text-mode read fails to round-trip (mojibake); the UTF-8 read round-trips byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
