### PR TITLE
fix(path): project path attribute case

### DIFF
--- a/src/ide_bridge/ide_daemon_helpers.py
+++ b/src/ide_bridge/ide_daemon_helpers.py
@@ -347,7 +347,7 @@ def _get_sync_folder():
         )
         if is_relative:
             project_path = ""
-            for attr in ["filename", "FileName", "FullName", "Path"]:
+            for attr in ["path", "filename", "FileName", "FullName", "Path"]:
                 try:
                     val = getattr(prj, attr)
                     if val:


### PR DESCRIPTION
path attribute may not be in camel case. Which causes the daemon to fail to locate files.

```
 cts compare
[ERROR] Sync export error: [Errno 13] [Errno 5] Access to the path '.\src' is denied.
```