### PR TITLE
fix(sync): make cts import apply ACTION edits (match IDE Project import behaviour)

### DIFF
--- a/cli/external_engine/xml_helpers.py
+++ b/cli/external_engine/xml_helpers.py
@@ -210,6 +210,27 @@ def _normalize_trailing_newline(text):
     return (text or "").rstrip() + "\n"
 
 
+def _action_name_from_entry(entry_element):
+    """Return the ACTION name carried under MetaObject/Name, or None.
+
+    CODESYS ACTIONs have no declaration section; their name lives on the
+    surrounding object metadata rather than in the projection body. We need
+    it to synthesise the ``ACTION <name>`` header on export so the projected
+    .st round-trips back through ``cts import``.
+    """
+    meta = _named_child_any(entry_element, "MetaObject")
+    if meta is None:
+        # Some snapshots serialise MetaObject one level down; fall back to a
+        # descendant search but stay scoped to a MetaObject ancestor.
+        meta = _named_descendant(entry_element, "Single", "MetaObject")
+    if meta is None:
+        return None
+    name_elem = _named_child_any(meta, "Name")
+    if name_elem is None or not (name_elem.text or "").strip():
+        return None
+    return name_elem.text.strip()
+
+
 def st_projection_content(entry_element):
     sections = _text_blob_sections(entry_element)
     if not sections:
@@ -238,6 +259,21 @@ def st_projection_content(entry_element):
             return (
                 _normalize_trailing_newline(declaration)
                 + "\n"
+                + ST_IMPLEMENTATION_MARKER
+                + "\n\n"
+                + _normalize_trailing_newline(implementation)
+            )
+    # ACTIONs (and other declaration-less POU children) carry only an
+    # implementation section. Synthesise the ``ACTION <name>`` header from the
+    # entry metadata so the projected .st is self-describing and round-trips
+    # through ``cts import``. Without this header, import sees a bare body and
+    # (per the _split_st_update_content fallback) refuses to update the IDE.
+    if not declarations and len(implementations) == 1:
+        implementation = implementations[0]
+        action_name = _action_name_from_entry(entry_element)
+        if action_name:
+            return (
+                "ACTION {0}\n".format(action_name)
                 + ST_IMPLEMENTATION_MARKER
                 + "\n\n"
                 + _normalize_trailing_newline(implementation)

--- a/src/ide_bridge/ide_handlers_sync.py
+++ b/src/ide_bridge/ide_handlers_sync.py
@@ -605,18 +605,36 @@ def _apply_text_to_object(target, decl, impl):
     decl_ok = True
     impl_ok = True
     if decl:
-        decl_ok = False
-        try:
-            decl_ok = _replace_text_document(target.textual_declaration, decl)
-        except Exception as e:
-            _log("Warning: could not set declaration: {0}".format(e))
+        decl_ok = _apply_text_section(target, "textual_declaration", decl)
     if impl:
-        impl_ok = False
-        try:
-            impl_ok = _replace_text_document(target.textual_implementation, impl)
-        except Exception as e:
-            _log("Warning: could not set implementation: {0}".format(e))
+        impl_ok = _apply_text_section(target, "textual_implementation", impl)
     return decl_ok, impl_ok
+
+
+def _apply_text_section(target, attr_name, text):
+    """Write text into getattr(target, attr_name).
+
+    Returns True when the section was written, OR when the object does not
+    expose that section at all (the attribute is missing or its document is
+    None). The latter is normal for declaration-less objects such as ACTIONs:
+    their textual_declaration is absent, so failing to "write the
+    declaration" is expected rather than an error. Only an actual write
+    failure against a present document returns False.
+    """
+    try:
+        doc = getattr(target, attr_name)
+    except Exception:
+        # Object type does not expose this section at all — treat as N/A.
+        return True
+    if doc is None:
+        # Section exists conceptually but this object has none (e.g. an ACTION
+        # has no declaration). Not a failure.
+        return True
+    try:
+        return _replace_text_document(doc, text)
+    except Exception as e:
+        _log("Warning: could not set {0}: {1}".format(attr_name, e))
+        return False
 
 
 def _apply_modified_st_objects(project, report_path):

--- a/src/ide_bridge/ide_handlers_sync.py
+++ b/src/ide_bridge/ide_handlers_sync.py
@@ -579,7 +579,11 @@ def _split_st_update_content(content):
     if marker in normalized:
         parts = normalized.split(marker, 1)
         return parts[0].strip(), parts[1].strip()
-    return normalized.strip(), ""
+    # No marker: the content is a bare body (e.g. an exported ACTION, which
+    # carries only an implementation). Treat it as the implementation, not the
+    # declaration, so _apply_text_to_object writes it to textual_implementation
+    # instead of misrouting it into textual_declaration and skipping the impl.
+    return "", normalized.strip()
 
 
 def _replace_text_document(doc, text):
@@ -693,7 +697,10 @@ def _split_st_content(content):
                 impl = impl.rstrip()[: -len(end_kw)].rstrip()
                 break
         return decl, impl
-    return normalized.strip(), ""
+    # No marker: bare body (e.g. exported ACTION with only an implementation).
+    # Treat it as the implementation, not the declaration, to avoid misrouting
+    # the body into textual_declaration. Mirror _split_st_update_content.
+    return "", normalized.strip()
 
 
 def _strip_text_creates(root):

--- a/tests/unit/test_ide_sync_st_helpers.py
+++ b/tests/unit/test_ide_sync_st_helpers.py
@@ -179,3 +179,93 @@ class TestSplitStContent:
         decl, impl = sync_module._split_st_content(content)
         assert decl == ""
         assert impl == "testVal := 5;"
+
+
+# ---------------------------------------------------------------------------
+# _apply_text_to_object — success semantics for declaration-less objects
+# ---------------------------------------------------------------------------
+
+
+class _WriteableDoc:
+    """Minimal stand-in for a CODESYS text document (supports .text assignment)."""
+
+    def __init__(self, initial=""):
+        self.text = initial
+
+
+class _StubTarget:
+    """Stand-in for a CODESYS object node.
+
+    ``textual_declaration`` / ``textual_implementation`` mirror the real API;
+    setting an attribute to None simulates an object that has no such section
+    (e.g. an ACTION has no declaration).
+    """
+
+    def __init__(self, *, has_declaration=True, has_implementation=True):
+        self.textual_declaration = _WriteableDoc() if has_declaration else None
+        self.textual_implementation = (
+            _WriteableDoc() if has_implementation else None
+        )
+
+
+class TestApplyTextToObject:
+    def test_writes_both_sections_for_full_pou(self, sync_module):
+        target = _StubTarget()
+        decl_ok, impl_ok = sync_module._apply_text_to_object(
+            target, "PROGRAM P\nVAR x:INT;END_VAR", "x := 1;"
+        )
+        assert decl_ok is True
+        assert impl_ok is True
+        assert target.textual_declaration.text == "PROGRAM P\nVAR x:INT;END_VAR"
+        assert target.textual_implementation.text == "x := 1;"
+
+    def test_action_with_declaration_header_still_reports_impl_ok(self, sync_module):
+        """Regression: when a user re-adds the ``ACTION <name>`` header to an
+        exported ACTION file and imports it, the header is parsed as the
+        declaration. An ACTION has no ``textual_declaration`` (it is None), so
+        ``_replace_text_document`` returns False for the declaration and the
+        old code reported the whole update as incomplete — even though the
+        implementation was written successfully. The implementation outcome
+        must be reported accurately (impl_ok=True) so the caller can count it
+        as updated instead of misclassifying it as skipped."""
+        target = _StubTarget(has_declaration=False)  # ACTION: no declaration
+        decl_ok, impl_ok = sync_module._apply_text_to_object(
+            target, "ACTION DoAct", "outVal := 999;"
+        )
+        # decl couldn't be written (object has no declaration section) — that
+        # is expected for an ACTION, not a failure of the import.
+        assert decl_ok is True  # treated as "nothing to write / N/A"
+        assert impl_ok is True
+        assert target.textual_implementation.text == "outVal := 999;"
+
+    def test_real_declaration_failure_is_still_reported(self, sync_module):
+        """If the object *does* expose a declaration section but writing into
+        it fails, decl_ok must still be False (we don't want to mask genuine
+        write failures for objects that genuinely have declarations)."""
+        target = _StubTarget(has_declaration=True)
+        # Force the declaration document to reject writes.
+        target.textual_declaration = _UnwriteableDoc()
+        decl_ok, impl_ok = sync_module._apply_text_to_object(
+            target, "PROGRAM P\nVAR x:INT;END_VAR", "x := 1;"
+        )
+        assert decl_ok is False
+        assert impl_ok is True
+
+    def test_empty_inputs_return_both_ok(self, sync_module):
+        target = _StubTarget()
+        decl_ok, impl_ok = sync_module._apply_text_to_object(target, "", "")
+        assert decl_ok is True
+        assert impl_ok is True
+
+
+class _UnwriteableDoc:
+    """A document-like object whose .text setter always raises, and which has
+    no .replace method, so _replace_text_document cannot succeed."""
+
+    @property
+    def text(self):
+        return ""
+
+    @text.setter
+    def text(self, value):
+        raise RuntimeError("write rejected")

--- a/tests/unit/test_ide_sync_st_helpers.py
+++ b/tests/unit/test_ide_sync_st_helpers.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+test_ide_sync_st_helpers.py – Unit tests for the pure ST-splitting helpers in
+``ide_handlers_sync.py``.
+
+These helpers (``_split_st_update_content`` / ``_split_st_content``) are pure
+string functions but live in a daemon module that imports the CODESYS .NET
+runtime at module load. We import the module with the runtime stubbed out so
+the helpers can be exercised without a live CODESYS instance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate ide_bridge directory
+# ---------------------------------------------------------------------------
+
+_IDE_BRIDGE = Path(__file__).parent.parent.parent / "src" / "ide_bridge"
+assert _IDE_BRIDGE.is_dir(), f"ide_bridge not found at {_IDE_BRIDGE}"
+
+
+# ---------------------------------------------------------------------------
+# .NET / CODESYS runtime stubbing (mirrors test_daemon_name_resolution.py)
+# ---------------------------------------------------------------------------
+
+
+class _AutoStub:
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __getattr__(self, name):
+        return self
+
+    def __iter__(self):
+        return iter([])
+
+
+_STUB = _AutoStub()
+
+
+def _make_stub_module(name):
+    mod = types.ModuleType(name)
+    mod.__spec__ = None
+
+    def _getattr(attr):
+        return _STUB
+
+    mod.__getattr__ = _getattr
+    return mod
+
+
+_STUB_NAMES = [
+    "clr",
+    "System",
+    "scriptengine",
+    "online",
+    "projects",
+    "scriptengine_events",
+]
+
+
+@pytest.fixture
+def sync_module():
+    """Import ide_handlers_sync with CODESYS runtime stubbed out."""
+    saved = {}
+    for name in _STUB_NAMES:
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = _make_stub_module(name)
+
+    if str(_IDE_BRIDGE) not in sys.path:
+        sys.path.insert(0, str(_IDE_BRIDGE))
+
+    # Evict any cached copy so we always import fresh.
+    evicted = sys.modules.pop("ide_handlers_sync", None)
+    evicted_common = sys.modules.pop("ide_runtime_common", None)
+    evicted_state = sys.modules.pop("ide_daemon_state", None)
+    evicted_helpers = sys.modules.pop("ide_daemon_helpers", None)
+
+    try:
+        mod = importlib.import_module("ide_handlers_sync")
+        yield mod
+    finally:
+        for key in (
+            "ide_handlers_sync",
+            "ide_runtime_common",
+            "ide_daemon_state",
+            "ide_daemon_helpers",
+        ):
+            sys.modules.pop(key, None)
+        # Restore prior module cache entries.
+        if evicted is not None:
+            sys.modules["ide_handlers_sync"] = evicted
+        if evicted_common is not None:
+            sys.modules["ide_runtime_common"] = evicted_common
+        if evicted_state is not None:
+            sys.modules["ide_daemon_state"] = evicted_state
+        if evicted_helpers is not None:
+            sys.modules["ide_daemon_helpers"] = evicted_helpers
+
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+# ---------------------------------------------------------------------------
+# _split_st_update_content
+# ---------------------------------------------------------------------------
+
+
+class TestSplitStUpdateContent:
+    def test_marked_content_splits_into_decl_and_impl(self, sync_module):
+        content = (
+            "ACTION DoAct\n"
+            "// --- implementation ---\n"
+            "\n"
+            "outVal := 999;"
+        )
+        decl, impl = sync_module._split_st_update_content(content)
+        assert "ACTION DoAct" in decl
+        assert impl == "outVal := 999;"
+
+    def test_bare_implementation_goes_to_impl_not_decl(self, sync_module):
+        """Regression: a bare implementation body (no marker, as produced by
+        ``cts export`` for declaration-less POU children such as ACTIONs) used
+        to be returned as the *declaration* with an empty implementation.
+        That caused ``_apply_text_to_object`` to write the body into
+        ``textual_declaration`` and skip the implementation entirely, so
+        edits to an exported ACTION never reached the IDE. The body must be
+        treated as the implementation when no marker is present."""
+        content = "testVal := 2;"  # bare body, no marker
+        decl, impl = sync_module._split_st_update_content(content)
+        assert decl == ""
+        assert impl == "testVal := 2;"
+
+    def test_empty_content_returns_empty_pair(self, sync_module):
+        decl, impl = sync_module._split_st_update_content("")
+        assert decl == ""
+        assert impl == ""
+
+    def test_none_content_returns_empty_pair(self, sync_module):
+        decl, impl = sync_module._split_st_update_content(None)
+        assert decl == ""
+        assert impl == ""
+
+
+# ---------------------------------------------------------------------------
+# _split_st_content (creation path)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitStContent:
+    def test_marked_content_splits_and_strips_end_keyword(self, sync_module):
+        content = (
+            "FUNCTION_BLOCK FB_X\n"
+            "VAR_INPUT\n  in : INT;\nEND_VAR\n"
+            "// --- implementation ---\n"
+            "\n"
+            "out := in;\n"
+            "END_FUNCTION_BLOCK"
+        )
+        decl, impl = sync_module._split_st_content(content)
+        assert "FUNCTION_BLOCK FB_X" in decl
+        assert "END_FUNCTION_BLOCK" not in impl  # stripped (API re-adds it)
+        assert "out := in;" in impl
+
+    def test_bare_implementation_goes_to_impl_not_decl(self, sync_module):
+        """Same regression class as the update path: a bare body must be
+        treated as implementation, not declaration."""
+        content = "testVal := 5;"
+        decl, impl = sync_module._split_st_content(content)
+        assert decl == ""
+        assert impl == "testVal := 5;"

--- a/tests/unit/test_xml_helpers.py
+++ b/tests/unit/test_xml_helpers.py
@@ -217,6 +217,24 @@ class TestStProjectionContent:
         impl.text = implementation
         return root
 
+    def _make_action_entry(self, name, implementation):
+        """Build a minimal ACTION entry element.
+
+        ACTIONs in CODESYS have **no declaration** — only an Implementation
+        section — plus a MetaObject/Name carrying the action's name. This
+        mirrors the real ``<父>.<动作>.xml`` shape captured by ``cts export``.
+        """
+        root = ET.Element("Single", {"Name": "Object"})
+        meta = ET.SubElement(root, "Single", {"Name": "MetaObject"})
+        name_elem = ET.SubElement(meta, "Single", {"Name": "Name"})
+        name_elem.text = name
+        impl_parent = ET.SubElement(root, "Single", {"Name": "Implementation"})
+        impl = ET.SubElement(
+            impl_parent, "Single", {"Name": "TextBlobForSerialisation"}
+        )
+        impl.text = implementation
+        return root
+
     def test_produces_declaration_and_implementation_with_marker(self):
         entry = self._make_entry(
             "PROGRAM MyPrg\nVAR\n  x : INT;\nEND_VAR",
@@ -230,6 +248,18 @@ class TestStProjectionContent:
 
     def test_none_for_empty_entry(self):
         assert st_projection_content(None) is None
+
+    def test_action_emits_keyword_marker_and_implementation(self):
+        """An ACTION (declaration-less) must project to a complete two-section
+        .st: ``ACTION <name>`` + marker + implementation. Currently it projects
+        to a bare implementation body, which ``cts import`` then refuses to
+        apply (regression: editing an exported ACTION never reaches the IDE)."""
+        entry = self._make_action_entry("TestAct2", "testVal := 1;")
+        result = st_projection_content(entry)
+        assert result is not None
+        assert "ACTION TestAct2" in result
+        assert ST_IMPLEMENTATION_MARKER in result
+        assert "testVal := 1;" in result
 
 
 class TestSplitStProjectionValues:


### PR DESCRIPTION
## Problem

Editing an ACTION's `.st` and running `cts import` silently fails to update
the IDE, while the IDE's own **Project import** applies the same edit. The
three commits here make `cts import` behave like Project import for ACTIONs
(and other declaration-less POU children).

Reproduced against `cts 2.8.1` (commit `1379524`) with a real CODESYS
project, PLC offline throughout.

## Symptom

Steps to reproduce:

1. `cts export` — the exported `<Parent>.<Action>.st` contains **only the
   bare implementation body** (no `ACTION <name>` header, no
   `// --- implementation ---` marker).
2. Edit the body, run `cts import`.
3. The object lands in `skipped_projection_objects` with reason
   `"projection change not applied automatically; use update-pou or edit
   in the IDE"`, and the IDE is **not** updated.
4. `cts compare` still reports the diff — compare and import disagree.

The only workarounds are `cts update-pou` (per-object) or the IDE's
Project import. For a project with many ACTIONs (state-machine action
methods, etc.) this makes the normal edit → import loop unusable.

## Root cause — three linked issues

### 1. Export drops the ACTION header (`st_projection_content`)

`cli/external_engine/xml_helpers.py` — ACTIONs in CODESYS carry only an
`Implementation` section and **no `Declaration`**. `st_projection_content`'s
"complete two-section" branch required `len(declarations) == 1`, which an
ACTION can never satisfy, so it fell through to `join_text_blob_values` and
emitted a bare body.

### 2. Import routes a bare body into the declaration slot (`_split_st_*`)

`src/ide_bridge/ide_handlers_sync.py` — both `_split_st_update_content` and
`_split_st_content` returned `(content, "")` when no marker was present,
i.e. the whole body went into the **declaration** slot and the
implementation was left empty. `_apply_text_to_object` then wrote the body
into `textual_declaration` (which an ACTION doesn't have) and skipped
`textual_implementation` entirely.

Issues #1 and #2 compose: export produces a bare file, and import is unable
to apply a bare file, so editing an exported ACTION never reaches the IDE.

### 3. Successful ACTION imports were reported as skipped (`_apply_text_to_object`)

Even when issue #2 is bypassed (e.g. user re-adds the header, or after
fix #2 applies), `_apply_text_to_object` returned `decl_ok=False` whenever a
declaration was requested but the target's `textual_declaration` was `None`
(normal for ACTIONs). `_apply_modified_st_objects` treated
`decl_ok and impl_ok` as success, so a successfully-written implementation
was still classified as incomplete and surfaced in
`skipped_projection_objects`.

## Fix

Three independent commits, each with its own tests:

| Commit | File | Change |
|---|---|---|
| `f599d05` | `xml_helpers.py` | `st_projection_content` synthesises `ACTION <name>` + marker from `MetaObject/Name` when the entry has exactly one implementation section and no declaration |
| `3ad767e` | `ide_handlers_sync.py` | `_split_st_update_content` / `_split_st_content` return `("", content)` in the no-marker fallback, so a bare body is treated as the implementation |
| `1e52efd` | `ide_handlers_sync.py` | Extract `_apply_text_section`, which returns `True` when the object exposes no such section (N/A, not a failure) and `False` only on a genuine write failure against a present document |

## Verification

**Unit tests:** `pytest tests/unit/` → `503 passed, 3 skipped` (the 3 skips
predate this PR). New coverage:

- `tests/unit/test_xml_helpers.py` — ACTION projection (declaration-less entry)
- `tests/unit/test_ide_sync_st_helpers.py` (new) — bare-body handling on both
  the update and creation paths, plus `_apply_text_to_object` success
  semantics for declaration-less objects and for genuine write failures

**End-to-end** against a live CODESYS 2.8.1 instance (PLC offline):

| Scenario | Before | After |
|---|---|---|
| `cts export` of an ACTION | bare body | `ACTION <name>` + marker + body |
| Edit ACTION `.st` → `cts import` (with header) | `skipped`, IDE unchanged | `updated_text_objects`, IDE updated |
| Edit bare ACTION `.st` → `cts import` | `skipped`, IDE unchanged | `updated_text_objects`, IDE updated |

After this PR, `cts import` on an ACTION behaves the same as the IDE's
Project import.

## Notes

- No change to the on-disk format of METHOD/POU/FB projections — those
  already carried their declaration and round-trip correctly.
- The `skipped_projection_objects` field is still emitted for objects whose
  projection format is genuinely non-ST; only the ACTION misclassification
  is fixed.
- All three fixes are independent and can be cherry-picked separately if
  preferred.
