### PR TITLE
Fix relative sync folder resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - `cts set-sync-folder [PATH] [--save]` writes the active project's `cds-sync-folder` property through the daemon. Omitting `PATH` automatically selects the saved project directory (`.`); explicit `./...` paths remain project-relative, while absolute paths are accepted directly.
 - The response reports both stored and resolved paths and calls out unsaved project state. `--save` persists the setting, with the same warning as import that saving also commits other pending IDE edits.
 
+**Relative sync-folder paths now resolve consistently:**
+
+- Every non-absolute sync-folder path is resolved against the saved `.project` file's directory across daemon, menu, external-UI, discovery, and snapshooter entry points. On Windows, `../sync` and `./../sync` now select the same directory, so they read the same sync-mode settings and produce the same text-first layout.
+
 ---
 
 ### Version 3.1.1 (2026-08-17)

--- a/products/codesys-host/src/ide_bridge/codesys_directory_operation.py
+++ b/products/codesys-host/src/ide_bridge/codesys_directory_operation.py
@@ -153,7 +153,7 @@ def set_base_directory(runtime, projects_obj):
     selected_path = selected_path.replace('/', os.sep).replace('\\', os.sep)
 
     # Check if path is relative
-    is_relative = selected_path.startswith('.' + os.sep) or selected_path == '.'
+    is_relative = not os.path.isabs(selected_path)
 
     # Save strictly to project properties
     try:

--- a/products/codesys-host/src/ide_bridge/codesys_external_ui_launcher.py
+++ b/products/codesys-host/src/ide_bridge/codesys_external_ui_launcher.py
@@ -15,6 +15,9 @@ import subprocess
 import threading
 import time
 
+from ide_daemon_state import _project_file_path
+from codesys_utils import _resolve_project_path
+
 READY_LINE = "CTS-UI-READY"
 READY_TIMEOUT_SECONDS = 8.0
 _INSTALL_HINT = 'Install the optional UI dependency with: pip install -e ".[ui]"'
@@ -44,22 +47,16 @@ def project_sync_folder(project):
             "Sync folder is not configured. Run Project_directory.py first."
         )
 
-    relative = not os.path.isabs(sync_folder)
-    if relative:
-        project_path = str(getattr(project, "path", "") or "").strip()
-        if not project_path:
-            return None, (
-                "Cannot resolve the relative sync folder because the project "
-                "has no saved file path. Save it, or configure an absolute "
-                "folder with Project_directory.py."
-            )
-        sync_folder = os.path.normpath(
-            os.path.join(
-                os.path.dirname(project_path),
-                sync_folder.replace("/", os.sep).replace("\\", os.sep),
-            )
+    sync_folder, relative = _resolve_project_path(
+        sync_folder, _project_file_path(project)
+    )
+    if relative and not sync_folder:
+        return None, (
+            "Cannot resolve the relative sync folder because the project "
+            "has no saved file path. Save it, or configure an absolute "
+            "folder with Project_directory.py."
         )
-    return os.path.abspath(sync_folder), None
+    return sync_folder, None
 
 
 def body_root():

--- a/products/codesys-host/src/ide_bridge/codesys_utils.py
+++ b/products/codesys-host/src/ide_bridge/codesys_utils.py
@@ -7,6 +7,33 @@ import os
 import sys
 
 
+def _resolve_project_path(path, project_file):
+    """Normalize *path* and anchor every relative form to *project_file*.
+
+    Returns ``(resolved_path, is_relative)``.  ``resolved_path`` is ``None``
+    when a relative path cannot be anchored because the project has no saved
+    file path.
+
+    Relative paths are defined by ``os.path.isabs`` rather than by a ``./``
+    prefix.  In particular, ``../sync`` and ``./../sync`` must resolve to the
+    same directory.
+    """
+    try:
+        text_type = unicode
+    except NameError:
+        text_type = str
+
+    value = text_type(path or "").strip()
+    value = value.replace("/", os.sep).replace("\\", os.sep)
+    is_relative = not os.path.isabs(value)
+    if is_relative:
+        project_file = text_type(project_file or "").strip()
+        if not project_file:
+            return None, True
+        value = os.path.join(os.path.dirname(project_file), value)
+    return os.path.normpath(value), is_relative
+
+
 def safe_str(value):
     if value is None:
         return ""
@@ -137,15 +164,13 @@ def load_base_dir():
         return None, "Project sync directory is not set. Run Project_directory.py first."
 
     base_dir = safe_str(base_dir).strip()
-    is_relative = base_dir == "." or base_dir.startswith("./") or base_dir.startswith(".\\")
-    if is_relative:
-        projects_obj = resolve_projects()
-        project = projects_obj.primary if projects_obj else None
-        project_path = safe_str(getattr(project, "path", ""))
-        if not project_path:
-            return None, "Cannot resolve relative sync directory: project path is not available."
-        project_dir = os.path.dirname(project_path)
-        base_dir = os.path.normpath(os.path.join(project_dir, base_dir.replace("/", os.sep).replace("\\", os.sep)))
+    projects_obj = resolve_projects()
+    project = projects_obj.primary if projects_obj else None
+    base_dir, is_relative = _resolve_project_path(
+        base_dir, safe_str(getattr(project, "path", ""))
+    )
+    if is_relative and not base_dir:
+        return None, "Cannot resolve relative sync directory: project path is not available."
 
     if not os.path.exists(base_dir):
         os.makedirs(base_dir)

--- a/products/codesys-host/src/ide_bridge/ide_daemon_helpers.py
+++ b/products/codesys-host/src/ide_bridge/ide_daemon_helpers.py
@@ -15,7 +15,14 @@ import time
 
 import ide_runtime_common as _common
 import ide_online_helpers as _helpers
-from ide_daemon_state import _json_safe, _build_path, _log, _obj_name, _project_file_path
+from ide_daemon_state import (
+    _json_safe,
+    _build_path,
+    _log,
+    _obj_name,
+    _project_file_path,
+)
+from codesys_utils import _resolve_project_path
 
 # ── Constants ─────────────────────────────────────────────────────────────
 
@@ -395,27 +402,18 @@ def _get_sync_folder():
                 "Sync folder not configured. Set 'cds-sync-folder' project property (Tools → Project_directory.py)",
             )
         base_dir = str(base_dir).strip()
-        # Resolve relative paths against the project file's directory.
-        is_relative = (
-            base_dir == "." or base_dir.startswith("./") or base_dir.startswith(".\\")
+        resolved, is_relative = _resolve_project_path(
+            base_dir, _project_file_path(prj)
         )
-        if is_relative:
-            project_path = _project_file_path(prj)
-            if not project_path:
-                return (
-                    None,
-                    "Relative cds-sync-folder '{0}' could not be anchored: the "
-                    "project exposes no file path (projects.primary has no "
-                    "path/filename). Save the project, or set cds-sync-folder to "
-                    "an absolute path via Project_directory.py.".format(base_dir),
-                )
-            project_dir = os.path.dirname(project_path)
-            base_dir = os.path.normpath(
-                os.path.join(
-                    project_dir, base_dir.replace("/", os.sep).replace("\\", os.sep)
-                )
+        if is_relative and not resolved:
+            return (
+                None,
+                "Relative cds-sync-folder '{0}' could not be anchored: the "
+                "project exposes no file path (projects.primary has no "
+                "path/filename). Save the project, or set cds-sync-folder to "
+                "an absolute path via Project_directory.py.".format(base_dir),
             )
-        return base_dir, None
+        return resolved, None
     except Exception as e:
         return None, str(e)
 

--- a/products/codesys-host/src/ide_bridge/ide_handlers_project.py
+++ b/products/codesys-host/src/ide_bridge/ide_handlers_project.py
@@ -25,6 +25,7 @@ from ide_daemon_state import (
     _get_plc_status_snapshot,
     _project_file_path,
 )
+from codesys_utils import _resolve_project_path
 
 from ide_daemon_helpers import (
     _get_project_info_object,
@@ -101,23 +102,9 @@ def _cmd_set_sync_folder(params):
     if "\x00" in path:
         return {"ok": False, "error": "Sync folder path contains a null byte"}
 
-    # Bare relative paths are ambiguous: CODESYS historically resolves them
-    # against its process working directory.  Require the established ./ form
-    # so every daemon consumer anchors the value against the project file.
-    portable_relative = (
-        path == "." or path.startswith("./") or path.startswith(".\\")
-    )
-    if not os.path.isabs(path) and not portable_relative:
-        return {
-            "ok": False,
-            "error": (
-                "Relative sync folder must be '.' or start with './'. "
-                "Pass an absolute path for a folder outside the project directory."
-            ),
-        }
-
     project_file = _project_file_path(project)
-    if portable_relative and not project_file:
+    resolved_path, is_relative = _resolve_project_path(path, project_file)
+    if is_relative and not resolved_path:
         return {
             "ok": False,
             "error": (
@@ -134,7 +121,9 @@ def _cmd_set_sync_folder(params):
         if not hasattr(props, "__setitem__"):
             return {"ok": False, "error": "Project properties are not writable"}
 
-        stored_path = os.path.normpath(path)
+        stored_path = os.path.normpath(
+            path.replace("/", os.sep).replace("\\", os.sep)
+        )
         props["cds-sync-folder"] = stored_path
         try:
             import socket
@@ -142,12 +131,6 @@ def _cmd_set_sync_folder(params):
             props["cds-sync-pc"] = socket.gethostname()
         except Exception as hostname_error:
             _log("Could not record sync-folder host: {0}".format(hostname_error))
-
-        resolved_path = stored_path
-        if portable_relative:
-            resolved_path = os.path.normpath(
-                os.path.join(os.path.dirname(project_file), stored_path)
-            )
 
         saved = False
         save_error = ""
@@ -709,14 +692,17 @@ def _cmd_probe_oa(params):
 
 
 def _sync_folder_for_project(project):
-    """Read the project's cds-sync-folder property, or "" if unavailable."""
+    """Read and resolve the project's cds-sync-folder property."""
     try:
         proj_info = _get_project_info_object(project)
         if proj_info is not None:
             props = _project_info_properties(proj_info)
             sf = props.get("cds-sync-folder", "")
             if sf:
-                return str(sf)
+                resolved, _is_relative = _resolve_project_path(
+                    sf, _project_file_path(project)
+                )
+                return resolved or ""
     except Exception as error:
         _log("Could not read project sync-folder property: {0}".format(error))
     return ""

--- a/products/codesys-host/src/ide_bridge/project_snapshooter.py
+++ b/products/codesys-host/src/ide_bridge/project_snapshooter.py
@@ -21,6 +21,8 @@ import time
 import ide_export_snapshot
 import ide_online_helpers as _helpers
 import ide_runtime_common
+from ide_daemon_state import _project_file_path
+from codesys_utils import _resolve_project_path
 
 
 class SnapshotOnlineError(RuntimeError):
@@ -77,24 +79,7 @@ def _resolve_log_sync_folder():
             except Exception:
                 proj = None
         if proj is not None:
-            try:
-                pi = proj.get_project_info()
-            except Exception:
-                pi = None
-            if pi is None:
-                try:
-                    pi = proj.project_info
-                except Exception:
-                    pi = None
-            if pi is not None:
-                values = getattr(pi, "values", pi)
-                try:
-                    sync = values["cds-sync-folder"]
-                except Exception:
-                    try:
-                        sync = values.get("cds-sync-folder", "")
-                    except Exception:
-                        sync = ""
+            sync = _sync_folder(proj)
     except Exception:
         sync = ""
     _SNAPSHOOTER_SYNC = sync or ""
@@ -321,7 +306,13 @@ def _read_project_property(project, key):
 
 
 def _sync_folder(project):
-    return _read_project_property(project, "cds-sync-folder")
+    configured = _read_project_property(project, "cds-sync-folder")
+    if not configured:
+        return ""
+    resolved, _is_relative = _resolve_project_path(
+        configured, _project_file_path(project)
+    )
+    return resolved or ""
 
 
 def _safe_filename(label):

--- a/tests/unit/test_codesys_external_ui_launcher.py
+++ b/tests/unit/test_codesys_external_ui_launcher.py
@@ -129,6 +129,20 @@ def test_project_sync_folder_resolves_relative_property():
     assert path == os.path.normpath(r"C:\Projects\Demo\sync")
 
 
+def test_project_sync_folder_treats_parent_relative_forms_equally():
+    launcher = _load_shared()
+
+    direct_parent, direct_error = launcher.project_sync_folder(_Project(r"..\sync"))
+    dotted_parent, dotted_error = launcher.project_sync_folder(
+        _Project(r".\..\sync")
+    )
+
+    expected = os.path.normpath(r"C:\Projects\sync")
+    assert direct_error is None
+    assert dotted_error is None
+    assert direct_parent == dotted_parent == expected
+
+
 def test_project_sync_folder_reports_when_unconfigured():
     launcher = _load_shared()
 

--- a/tests/unit/test_project_file_path.py
+++ b/tests/unit/test_project_file_path.py
@@ -25,6 +25,8 @@ if _IDE_BRIDGE not in sys.path:
     sys.path.insert(0, _IDE_BRIDGE)
 
 import ide_daemon_state as state
+import ide_daemon_helpers as helpers
+import codesys_utils
 
 
 class _LowerPathProject(object):
@@ -74,3 +76,63 @@ def test_missing_path_returns_empty_string():
 
 def test_raising_attribute_falls_through():
     assert state._project_file_path(_RaisingProject()) == r"E:\fallback\Fallback.project"
+
+
+class _Info(object):
+    def __init__(self, sync_folder):
+        self.values = {"cds-sync-folder": sync_folder}
+
+
+class _ConfiguredProject(object):
+    def __init__(self, path, sync_folder):
+        self.path = path
+        self.info = _Info(sync_folder)
+
+    def get_project_info(self):
+        return self.info
+
+
+class _Projects(object):
+    def __init__(self, project):
+        self.primary = project
+
+
+def test_parent_relative_forms_resolve_to_the_same_directory(monkeypatch, tmp_path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    project = _ConfiguredProject(str(project_dir / "Demo.project"), "../sync")
+    projects = _Projects(project)
+    monkeypatch.setattr(
+        sys,
+        "_codesys_daemon_loop",
+        {"projects": projects},
+        raising=False,
+    )
+
+    direct_parent, direct_error = helpers._get_sync_folder()
+    project.info.values["cds-sync-folder"] = "./../sync"
+    dotted_parent, dotted_error = helpers._get_sync_folder()
+
+    expected = os.path.normpath(str(tmp_path / "sync"))
+    assert direct_error is None
+    assert dotted_error is None
+    assert direct_parent == dotted_parent == expected
+
+
+def test_legacy_operations_use_the_same_parent_relative_resolution(
+    monkeypatch, tmp_path
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    project = _ConfiguredProject(str(project_dir / "Demo.project"), "../sync")
+    projects = _Projects(project)
+    monkeypatch.setattr(codesys_utils, "resolve_projects", lambda *args: projects)
+
+    direct_parent, direct_error = codesys_utils.load_base_dir()
+    project.info.values["cds-sync-folder"] = "./../sync"
+    dotted_parent, dotted_error = codesys_utils.load_base_dir()
+
+    expected = os.path.normpath(str(tmp_path / "sync"))
+    assert direct_error is None
+    assert dotted_error is None
+    assert direct_parent == dotted_parent == expected

--- a/tests/unit/test_project_snapshooter.py
+++ b/tests/unit/test_project_snapshooter.py
@@ -37,6 +37,18 @@ class DummyProject:
     pass
 
 
+class ProjectWithSyncFolder:
+    path = r"C:\Projects\Demo\Demo.project"
+
+    def __init__(self, sync_folder):
+        self.info = type(
+            "Info", (), {"values": {"cds-sync-folder": sync_folder}}
+        )()
+
+    def get_project_info(self):
+        return self.info
+
+
 class DummyText:
     def __init__(self, text):
         self.text = text
@@ -191,6 +203,18 @@ def test_default_preset_path_uses_sync_folder(monkeypatch):
     path = ps._default_preset_path(DummyProject(), "speed tuning")
 
     assert path == r"C:\Sync\.dump\snapshots\speed-tuning.json"
+
+
+def test_default_preset_path_resolves_parent_relative_sync_folder():
+    direct_parent = ps._default_preset_path(
+        ProjectWithSyncFolder(r"..\sync"), "speed tuning"
+    )
+    dotted_parent = ps._default_preset_path(
+        ProjectWithSyncFolder(r".\..\sync"), "speed tuning"
+    )
+
+    expected = r"C:\Projects\sync\.dump\snapshots\speed-tuning.json"
+    assert direct_parent == dotted_parent == expected
 
 
 def test_ensure_default_snapshot_dir_creates_directory(monkeypatch, tmp_path):

--- a/tests/unit/test_set_sync_folder.py
+++ b/tests/unit/test_set_sync_folder.py
@@ -83,15 +83,19 @@ def test_explicit_unicode_absolute_path_is_stored_without_saving(monkeypatch, tm
     assert project.save_calls == 0
 
 
-def test_bare_relative_path_is_rejected(monkeypatch, tmp_path):
-    project = _Project(str(tmp_path / "Demo.project"))
+def test_parent_relative_path_is_anchored_to_project_directory(monkeypatch, tmp_path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    project = _Project(str(project_dir / "Demo.project"))
     _install_project(monkeypatch, project)
 
-    result = handlers._cmd_set_sync_folder({"path": "sync"})
+    result = handlers._cmd_set_sync_folder({"path": "../sync"})
 
-    assert result["ok"] is False
-    assert "start with './'" in result["error"]
-    assert "cds-sync-folder" not in project.info.values
+    assert result["ok"] is True
+    assert project.info.values["cds-sync-folder"] == os.path.normpath("../sync")
+    assert result["data"]["resolved_sync_folder"] == os.path.normpath(
+        str(tmp_path / "sync")
+    )
 
 
 def test_automatic_path_requires_a_saved_project(monkeypatch):


### PR DESCRIPTION
Fixes #65

## Problem

CODESYS-side sync-folder consumers only recognized `.`, `./...`, and `.\...` as relative paths. The equivalent `../sync` form bypassed project-relative anchoring, so commands could read or write a different sync root and miss the intended Text-first settings.

## Changes

- Add one shared path normalizer that treats every non-absolute path as relative to the saved `.project` file.
- Use the same resolver in daemon sync, legacy menu operations, external UI launchers, project discovery, and snapshooter paths.
- Allow `cts set-sync-folder` to accept standard relative paths such as `../sync`.
- Add regression coverage proving that `../sync` and `./../sync` resolve identically across those entry points.
- Document the corrected behavior in the changelog.

## Validation

- `python -m pytest tests/unit -q` — 1329 passed, 19 skipped
- `python tools/compat_check.py` — 0 errors
- `python tools/ci_analyze_checks.py` — passed
- `python tools/ci_product_checks.py wheels` — passed
- Ruff on all changed files — passed

`tools/ci_product_checks.py manifests` still reports the pre-existing unowned `tests/unit/test_reverse_pipe_client.py` file at upstream HEAD; this PR does not modify that file or the ownership manifests.